### PR TITLE
Store queue times for pending jobs (raw data)

### DIFF
--- a/cq_examples.sql
+++ b/cq_examples.sql
@@ -2,21 +2,21 @@ CREATE RETENTION POLICY "1week" ON <database> DURATION 7d REPLICATION 1
 
 CREATE CONTINUOUS QUERY "cq_time_pending_1day_partition" ON <database>
 BEGIN
-  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_daily" FROM "partition_jobs_time_pending" GROUP BY time(1d),*
+  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_daily" FROM "1week"."partition_jobs_time_pending" GROUP BY time(1d),*
 END
 
 CREATE CONTINUOUS QUERY "cq_time_pending_1day_group" ON <database>
 BEGIN
-  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_daily" FROM "group_jobs_time_pending" GROUP BY time(1d),*
+  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_daily" FROM "1week"."group_jobs_time_pending" GROUP BY time(1d),*
 END
 
 
 CREATE CONTINUOUS QUERY "cq_time_pending_1week_partition" ON <database>
 BEGIN
-  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_weekly" FROM "partition_jobs_time_pending" GROUP BY time(7d),*
+  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_weekly" FROM "partition_jobs_time_pending_daily" GROUP BY time(7d),*
 END
 
 CREATE CONTINUOUS QUERY "cq_time_pending_1week_group" ON <database>
 BEGIN
-  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_weekly" FROM "group_jobs_time_pending" GROUP BY time(7d),*
+  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_weekly" FROM "group_jobs_time_pending_daily" GROUP BY time(7d),*
 END

--- a/cq_examples.sql
+++ b/cq_examples.sql
@@ -1,0 +1,22 @@
+CREATE RETENTION POLICY "1week" ON <database> DURATION 7d REPLICATION 1
+
+CREATE CONTINUOUS QUERY "cq_time_pending_1day_partition" ON <database>
+BEGIN
+  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_daily" FROM "partition_jobs_time_pending" GROUP BY time(1d),*
+END
+
+CREATE CONTINUOUS QUERY "cq_time_pending_1day_group" ON <database>
+BEGIN
+  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_daily" FROM "group_jobs_time_pending" GROUP BY time(1d),*
+END
+
+
+CREATE CONTINUOUS QUERY "cq_time_pending_1week_partition" ON <database>
+BEGIN
+  SELECT MAX("jobs_time_pending") INTO "partition_jobs_time_pending_weekly" FROM "partition_jobs_time_pending" GROUP BY time(7d),*
+END
+
+CREATE CONTINUOUS QUERY "cq_time_pending_1week_group" ON <database>
+BEGIN
+  SELECT MAX("jobs_time_pending") INTO "group_jobs_time_pending_weekly" FROM "group_jobs_time_pending" GROUP BY time(7d),*
+END

--- a/main.py
+++ b/main.py
@@ -97,7 +97,8 @@ user_ids = {}
 user_groups = {}
 user_ldap = {}
 
-now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+now = datetime.datetime.utcnow()
+now_str = now.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 # Setup data structures, with stats set to 0
 for part in partitions.keys() + ['ALL']:
@@ -286,6 +287,6 @@ for grouping in ['partition', 'user', 'group', 'ldap_attrib']:
     for reading in ['cpu_total', 'cpu_usage', 'cpu_usage_pc', 'gpu_total', 'gpu_usage', 'gpu_usage_pc', 'mem_total', 'mem_usage', 'mem_usage_pc', 'jobs_running', 'jobs_pending', 'queue_time']:
         if reading in metrics[grouping] and len(metrics[grouping][reading]) > 0:
             for key in metrics[grouping][reading].keys():
-                payload.append({'measurement': '%s_%s' % (grouping, reading), 'time': now, 'fields': {reading: float(metrics[grouping][reading][key])}, 'tags': {grouping: key}})
+                payload.append({'measurement': '%s_%s' % (grouping, reading), 'time': now_str, 'fields': {reading: float(metrics[grouping][reading][key])}, 'tags': {grouping: key}})
 
 client.write_points(payload, database=config['influxdb_database'])

--- a/main.py
+++ b/main.py
@@ -291,13 +291,14 @@ for job in jobs:
             metrics['ldap_attrib']['jobs_pending'][user_ldap[user]] += 1
 
 payload = []
-
 for grouping in ['partition', 'user', 'group', 'ldap_attrib']:
     for reading in ['cpu_total', 'cpu_usage', 'cpu_usage_pc', 'gpu_total', 'gpu_usage', 'gpu_usage_pc', 'mem_total', 'mem_usage', 'mem_usage_pc', 'jobs_running', 'jobs_pending', 'queue_time']:
         if reading in metrics[grouping] and len(metrics[grouping][reading]) > 0:
             for key in metrics[grouping][reading].keys():
                 payload.append({'measurement': '%s_%s' % (grouping, reading), 'time': now_str, 'fields': {reading: float(metrics[grouping][reading][key])}, 'tags': {grouping: key}})
+client.write_points(payload, database=config['influxdb_database'])
 
+payload = []
 for grouping in ['partition', 'group']:
     for reading in ['jobs_time_pending']:
         if reading in metrics[grouping] and len(metrics[grouping][reading]) > 0:
@@ -305,5 +306,4 @@ for grouping in ['partition', 'group']:
                 if len(metrics[grouping][reading][key]) > 0:
                     for jid in metrics[grouping][reading][key].keys():
                         payload.append({ 'measurement': '{grouping}_{reading}'.format(grouping=grouping,reading=reading), 'time': now_str, 'fields': {reading: float(metrics[grouping][reading][key][jid])}, 'tags': {'job_id': jid, grouping: key} })
-
-client.write_points(payload, database=config['influxdb_database'])
+client.write_points(payload, database=config['influxdb_database'], retention_policy='1week')

--- a/main.py
+++ b/main.py
@@ -64,6 +64,7 @@ metrics['partition']['jobs_running'] = {}
 metrics['partition']['jobs_pending'] = {}
 metrics['partition']['queue_time'] = {}
 metrics['partition']['queue_jobs'] = {}
+metrics['partition']['jobs_time_pending'] = {}
 
 metrics['user'] = {}
 metrics['user']['cpu_usage'] = {}
@@ -82,6 +83,7 @@ metrics['group']['jobs_running'] = {}
 metrics['group']['jobs_pending'] = {}
 metrics['group']['queue_time'] = {}
 metrics['group']['queue_jobs'] = {}
+metrics['group']['jobs_time_pending'] = {}
 
 if config['user_lookup']:
     metrics['ldap_attrib'] = {}
@@ -123,6 +125,7 @@ for part in partitions.keys() + ['ALL']:
     metrics['partition']['jobs_pending'][part] = 0
     metrics['partition']['queue_time'][part] = 0
     metrics['partition']['queue_jobs'][part] = 0
+    metrics['partition']['jobs_time_pending'][part] = {}
 
 for group in groups:
     metrics['group']['cpu_usage'][group] = 0
@@ -132,6 +135,7 @@ for group in groups:
     metrics['group']['jobs_pending'][group] = 0
     metrics['group']['queue_time'][group] = 0
     metrics['group']['queue_jobs'][group] = 0
+    metrics['group']['jobs_time_pending'][group] = {}
 
     members = grp.getgrnam(group)[3]
     for user in members:
@@ -269,24 +273,37 @@ for job in jobs:
             metrics['ldap_attrib']['queue_time'][user_ldap[user]] = (float(metrics['ldap_attrib']['queue_time'][user_ldap[user]] + queue_time)) / metrics['ldap_attrib']['queue_jobs'][user_ldap[user]]
 
     elif job['job_state'] == 'PENDING':
+        time_pending = (now - datetime.datetime.utcfromtimestamp(job['submit_time'])).total_seconds()
         metrics['partition']['jobs_pending']['ALL'] += 1
+        metrics['partition']['jobs_time_pending']['ALL'][job['job_id']] = time_pending  # Not sure 'ALL' is really needed for this metric, but for consistency do it anyway
         for partition in job['partition'].split(','):
             metrics['partition']['jobs_pending'][partition] += 1
+            metrics['partition']['jobs_time_pending'][partition][job['job_id']] = time_pending
 
         metrics['user']['jobs_pending'][user] += 1
 
         if user in user_groups:
             for group in user_groups[user]:
                 metrics['group']['jobs_pending'][group] += 1
+                metrics['group']['jobs_time_pending'][group][job['job_id']] = time_pending
 
         if config['user_lookup']:
             metrics['ldap_attrib']['jobs_pending'][user_ldap[user]] += 1
 
 payload = []
+
 for grouping in ['partition', 'user', 'group', 'ldap_attrib']:
     for reading in ['cpu_total', 'cpu_usage', 'cpu_usage_pc', 'gpu_total', 'gpu_usage', 'gpu_usage_pc', 'mem_total', 'mem_usage', 'mem_usage_pc', 'jobs_running', 'jobs_pending', 'queue_time']:
         if reading in metrics[grouping] and len(metrics[grouping][reading]) > 0:
             for key in metrics[grouping][reading].keys():
                 payload.append({'measurement': '%s_%s' % (grouping, reading), 'time': now_str, 'fields': {reading: float(metrics[grouping][reading][key])}, 'tags': {grouping: key}})
+
+for grouping in ['partition', 'group']:
+    for reading in ['jobs_time_pending']:
+        if reading in metrics[grouping] and len(metrics[grouping][reading]) > 0:
+            for key in metrics[grouping][reading].keys():
+                if len(metrics[grouping][reading][key]) > 0:
+                    for jid in metrics[grouping][reading][key].keys():
+                        payload.append({ 'measurement': '{grouping}_{reading}'.format(grouping=grouping,reading=reading), 'time': now_str, 'fields': {reading: float(metrics[grouping][reading][key][jid])}, 'tags': {'job_id': jid, grouping: key} })
 
 client.write_points(payload, database=config['influxdb_database'])


### PR DESCRIPTION
These changes expand the data stored to include the time spent in the queue for pending (currently queuing) jobs.
Rather than compute an average at this point, the time for all jobs is stored separately (identified by tagging with job ID).
An example of appropriate retention policy and continuous queries to downsample the data are included (in order to avoid bloating the database).